### PR TITLE
[BUG] Fix typo in module alias

### DIFF
--- a/virtualscanner/server/simulation/bloch/pulseq_bloch_simulator.py
+++ b/virtualscanner/server/simulation/bloch/pulseq_bloch_simulator.py
@@ -24,7 +24,7 @@ import numpy as np
 import virtualscanner.server.simulation.bloch.pulseq_blochsim_methods as blcsim
 
 matplotlib.use('Agg')
-import matplotlib.pyplot as pltw
+import matplotlib.pyplot as plt
 import time
 import virtualscanner.server.simulation.bloch.phantom as pht
 import multiprocessing as mp


### PR DESCRIPTION
### Fixes #

GRE exam crashes when run, due to a typo in a module alias [here](https://github.com/imr-framework/virtual-scanner/commit/5755c69723bfe90894a89744795ca4eb42918e8d#diff-f4d8a32d8ca6c0f3d96c0ca41e55c21dR27) introduced in 5755c69723bfe90894a89744795ca4eb42918e8d

### Proposed changes

Rename `pltw` as `plt`